### PR TITLE
ci: `main` instead of `master`

### DIFF
--- a/.github/workflows/deploy-gh-pages.yaml
+++ b/.github/workflows/deploy-gh-pages.yaml
@@ -3,7 +3,7 @@ name: Deploy Website to Github Pages
 on:
   push:
     branches:
-      - master
+      - main
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:


### PR DESCRIPTION
Typo in workflow