### PR TITLE
ci: ensure website is re-deployed after mod-source update

### DIFF
--- a/.github/workflows/deploy-gh-pages.yaml
+++ b/.github/workflows/deploy-gh-pages.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_call: {}
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:

--- a/.github/workflows/update-mod-source.yaml
+++ b/.github/workflows/update-mod-source.yaml
@@ -40,3 +40,10 @@ jobs:
         with:
           message: "source: Updated mod source data"
           push: true
+
+  deploy_website:
+    name: "Deploy Website Changes"
+    needs:
+      - update-mod-source
+    uses: ./.github/workflows/deploy-gh-pages.yaml
+    secrets: inherit


### PR DESCRIPTION
Workflows cannot implicitly trigger other workflows (when they use the default token).  Explicitly call the deployment workflow after we've pushed to `main`.  This should work...but will need to be tested to really find out.